### PR TITLE
refactor/from-br-to-racket-base (#12)

### DIFF
--- a/expander-helpers/game.rkt
+++ b/expander-helpers/game.rkt
@@ -1,4 +1,6 @@
-#lang racket
+#lang racket/base
+
+(require racket/class racket/list racket/string racket/vector)
 
 ; Terminology:
 ;

--- a/expander-helpers/renderer.rkt
+++ b/expander-helpers/renderer.rkt
@@ -1,4 +1,6 @@
-#lang racket
+#lang racket/base
+
+(require racket/class)
 
 (define puzzler-renderer%
   (class object%

--- a/expander.rkt
+++ b/expander.rkt
@@ -1,10 +1,10 @@
-#lang br/quicklang
+#lang racket/base
 
-(require racket/gui/base)
-(require racket/draw)
-(require racket/set)
 (require "./expander-helpers/game.rkt")
 (require "./expander-helpers/renderer.rkt")
+
+(require racket/gui racket/draw racket/set racket/class)
+(require br/define)
 
 ; The game's rendering component
 (define renderer (new puzzler-renderer%))
@@ -80,7 +80,7 @@
   (set! inner-goal-map-index 0))
 
 (define-macro (puzzler-map ROW ...)
-  (with-pattern ([CALLER-STX (syntax->datum caller-stx)])
+  (with-syntax ([CALLER-STX (syntax->datum caller-stx)])
     #'(let ([calling-pattern 'CALLER-STX])
         (send renderer setup-draw-calculations! (length (cdr calling-pattern)))
         (add-map-vector (length (cdr calling-pattern)))
@@ -482,3 +482,5 @@
     (> (set-count same-positions) 0)))
 
 (send game-frame show #t)
+
+(provide #%datum #%app #%top-interaction)

--- a/info.rkt
+++ b/info.rkt
@@ -1,4 +1,4 @@
 #lang info
 (define version "0.1")
-(define deps (list "beautiful-racket" "brag" "draw-lib" "gui-lib" "base"))
+(define deps (list "beautiful-racket" "brag" "draw-lib" "gui-lib" "base" "parser-tools-lib"))
 (define test-omit-paths (list "examples" "expander.rkt"))

--- a/main.rkt
+++ b/main.rkt
@@ -1,11 +1,12 @@
-#lang br/quicklang
+#lang racket/base
 
 (require "tokenizer.rkt" "parser.rkt")
+(require syntax/strip-context)
 
 (module+ reader
   (provide read-syntax))
 (define (read-syntax path port)
   (define parse-tree (parse path (make-tokenizer port)))
-  (strip-bindings
+  (strip-context
    #`(module puzzler-mod puzzler/expander
        #,parse-tree)))

--- a/parse-tree-test.rkt
+++ b/parse-tree-test.rkt
@@ -1,4 +1,4 @@
-#lang br
+#lang racket/base
 (require puzzler/tokenizer puzzler/parser brag/support)
 
 (parse-to-datum (apply-tokenizer-maker make-tokenizer

--- a/tokenizer.rkt
+++ b/tokenizer.rkt
@@ -1,6 +1,6 @@
-#lang br
+#lang racket/base
+
 (require brag/support)
-(require br-parser-tools/lex-sre)
 
 (define (make-tokenizer port)
   (define (next-token)
@@ -31,9 +31,9 @@
         ["START_GOAL_MAP" (token 'START-GOAL-MAP-TOKEN lexeme)]
         ["END_GOAL_MAP" (token 'END-GOAL-MAP-TOKEN lexeme)]
         ["->" (token 'RULE-RESULT-TOKEN lexeme)]
-        [(or (:= 1 alphabetic) (:= 1 "#"))
+        [(union (:= 1 alphabetic) (:= 1 "#"))
          (token 'MAP-CHAR-TOKEN lexeme)]
-        [(or (:= 1 numeric) (:: "-" (:= 1 numeric)))
+        [(union (:= 1 numeric) (:: "-" (:= 1 numeric)))
          (token 'NUM-TOKEN lexeme)]
         [any-char (token lexeme)]))
     (puzzler-lexer port))


### PR DESCRIPTION
* Converting all source files to racket/base instead of br, removing most of the dependencies to br libraries, but still using br/define in expander

* Removing comment after decision to use br libraries in expander